### PR TITLE
fix timers name not updating

### DIFF
--- a/app/src/main/java/com/ledwon/jakub/chessclock/feature/choose_timer/ChooseTimerScreen.kt
+++ b/app/src/main/java/com/ledwon/jakub/chessclock/feature/choose_timer/ChooseTimerScreen.kt
@@ -175,7 +175,7 @@ fun TimeCard(
         Column(modifier = Modifier.padding(8.dp), horizontalAlignment = Alignment.Start) {
             Text(
                 modifier = Modifier.align(Alignment.CenterHorizontally),
-                text = timer.obtainName().getAndRemember(),
+                text = timer.obtainName().get(),
                 color = MaterialTheme.colors.onSurface,
                 fontSize = 19.sp
             )


### PR DESCRIPTION
 Timers name would not get recomposed because we used getAndRemember() to obtain its name.